### PR TITLE
Fix C++ error in erf function

### DIFF
--- a/R/PlotRsmOperatingCharacteristics.R
+++ b/R/PlotRsmOperatingCharacteristics.R
@@ -461,7 +461,7 @@ xROCVect <- function(zeta, lambdaP) {
   return (FPF);
 }
 
-
-erfcpp <- function(x){
-  return (2 * pnorm(sqrt(2) * x) - 1)
+# R-only implementation of erf function
+erf_R <- function(x){
+ return (2 * pnorm(sqrt(2) * x) - 1)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -77,8 +77,8 @@ ExpTrnsfmSp <- function(nl, ll, n_lesions_per_image, max_cases, max_nl, max_ll) 
     .Call('_RJafroc_ExpTrnsfmSp', PACKAGE = 'RJafroc', nl, ll, n_lesions_per_image, max_cases, max_nl, max_ll)
 }
 
-erf <- function(x) {
-    .Call('_RJafroc_erf', PACKAGE = 'RJafroc', x)
+erfcpp <- function(x) {
+    .Call('_RJafroc_erfcpp', PACKAGE = 'RJafroc', x)
 }
 
 erfVect <- function(x) {

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -303,14 +303,14 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// erf
-double erf(double x);
-RcppExport SEXP _RJafroc_erf(SEXP xSEXP) {
+// erfcpp
+double erfcpp(double x);
+RcppExport SEXP _RJafroc_erfcpp(SEXP xSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< double >::type x(xSEXP);
-    rcpp_result_gen = Rcpp::wrap(erf(x));
+    rcpp_result_gen = Rcpp::wrap(erfcpp(x));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -473,7 +473,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_RJafroc_MaxNLF", (DL_FUNC) &_RJafroc_MaxNLF, 6},
     {"_RJafroc_MaxNLFAllCases", (DL_FUNC) &_RJafroc_MaxNLFAllCases, 6},
     {"_RJafroc_ExpTrnsfmSp", (DL_FUNC) &_RJafroc_ExpTrnsfmSp, 6},
-    {"_RJafroc_erf", (DL_FUNC) &_RJafroc_erf, 1},
+    {"_RJafroc_erfcpp", (DL_FUNC) &_RJafroc_erfcpp, 1},
     {"_RJafroc_erfVect", (DL_FUNC) &_RJafroc_erfVect, 1},
     {"_RJafroc_xROC", (DL_FUNC) &_RJafroc_xROC, 2},
     {"_RJafroc_xROCVect", (DL_FUNC) &_RJafroc_xROCVect, 2},

--- a/src/RsmFuncs.cpp
+++ b/src/RsmFuncs.cpp
@@ -2,10 +2,16 @@
 #include "CommonFuncs.h"
 using namespace Rcpp;
 
+/* This function clashes with with std::erf(double) in math.h (since C++11)
+   See <https://en.cppreference.com/w/cpp/numeric/math/erf>
+   It does not appear to be called by any of the *.R *.Rmd *.Rd or *.cpp files
+   This function could be renamed and call the std:erf, once all CRAN platforms
+   are using C++11.
 // [[Rcpp::export]]
 double erf(double x){
   return 2 * R::pnorm(sqrt(2.0) * x, 0, 1, 1, 0) - 1;
 }
+*/
 
 // [[Rcpp::export]]
 NumericVector erfVect(NumericVector x){
@@ -17,6 +23,7 @@ NumericVector erfVect(NumericVector x){
   return erfx;
 }
 
+/* Candidate for Rcpp::export, if required */
 double erfcpp(double x){
   return 2 * R::pnorm(sqrt(2.0) * x, 0, 1, 1, 0) - 1;
 }

--- a/src/RsmFuncs.cpp
+++ b/src/RsmFuncs.cpp
@@ -2,17 +2,10 @@
 #include "CommonFuncs.h"
 using namespace Rcpp;
 
-/* This function clashes with with std::erf(double) in cmath (since C++11). See 
-   - <https://en.cppreference.com/w/cpp/numeric/math/erf>
-   - <http://www.cplusplus.com/reference/cmath/erf/>
-   It does not appear to be called by any of the *.R *.Rmd *.Rd or *.cpp files
-   This function could be renamed and call the std:erf, once all CRAN platforms
-   are using C++11.
 // [[Rcpp::export]]
-double erf(double x){
+double erfcpp(double x){
   return 2 * R::pnorm(sqrt(2.0) * x, 0, 1, 1, 0) - 1;
 }
-*/
 
 // [[Rcpp::export]]
 NumericVector erfVect(NumericVector x){
@@ -22,11 +15,6 @@ NumericVector erfVect(NumericVector x){
     erfx[il] = 2 * R::pnorm(sqrt(2.0) * x[il], 0, 1, 1, 0) - 1;
   }
   return erfx;
-}
-
-/* Candidate for Rcpp::export, if required */
-double erfcpp(double x){
-  return 2 * R::pnorm(sqrt(2.0) * x, 0, 1, 1, 0) - 1;
 }
 
 // [[Rcpp::export]]

--- a/src/RsmFuncs.cpp
+++ b/src/RsmFuncs.cpp
@@ -2,8 +2,9 @@
 #include "CommonFuncs.h"
 using namespace Rcpp;
 
-/* This function clashes with with std::erf(double) in math.h (since C++11)
-   See <https://en.cppreference.com/w/cpp/numeric/math/erf>
+/* This function clashes with with std::erf(double) in cmath (since C++11). See 
+   - <https://en.cppreference.com/w/cpp/numeric/math/erf>
+   - <http://www.cplusplus.com/reference/cmath/erf/>
    It does not appear to be called by any of the *.R *.Rmd *.Rd or *.cpp files
    This function could be renamed and call the std:erf, once all CRAN platforms
    are using C++11.


### PR DESCRIPTION
Rename the `erf` function is renamed to `erfcpp` and exposed to R. The R implementation is renamed `erf_R`, and kept for future performance testing.

This pull request is against Dev's `development` branch, rather than `master`, and should go some way to addressing the CRAN error.