### PR TITLE
Add simple tests using the testthat package

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,5 @@
+library(testthat)
+library(RJafroc)
+
+test_check("RJafroc")
+

--- a/tests/testthat/test-BinormalFit.R
+++ b/tests/testthat/test-BinormalFit.R
@@ -1,0 +1,10 @@
+context("PlotBinormalFit tests")
+library(RJafroc)
+
+test_that("PlotBinormalFit should return a gg/ggplot", {
+    aArray <- c(0.7, 0.7, 1.5, 2)
+    bArray <- c(0.5, 1.5, 0.5, 0.5)
+    p <- PlotBinormalFit(aArray, bArray)
+    expect_is( (p),c("gg","ggplot") )
+})
+

--- a/tests/testthat/test-FitBinormalRoc.R
+++ b/tests/testthat/test-FitBinormalRoc.R
@@ -1,0 +1,19 @@
+context("FitBinormalRoc tests")
+library(RJafroc)
+
+# Simple tests to check that FitBinormalRoc is working
+
+test_that("FitBinormalRoc should error on degenerate data", {
+ expect_warning(FitBinormalRoc(datasetDegenerate),"Data is degenerate" )
+})
+
+ds <- DfFroc2Roc(dataset01)
+retFit <- FitBinormalRoc(ds, 2, 3)
+
+test_that("FitBinormalRoc should return a class that is gg and ggplot", {
+  expect_is( retFit$fittedPlot,c("gg","ggplot") )
+})
+
+test_that("FitBinormalRoc$ChisqrFitStats$chisq value using dataset01", {
+  expect_equal( retFit$ChisqrFitStats$chisq,15.71449806 ) # hardcoded value for chisq for now
+})

--- a/tests/testthat/test-PlotCbmFit.R
+++ b/tests/testthat/test-PlotCbmFit.R
@@ -1,0 +1,11 @@
+context("PlotCbmFit tests")
+library(RJafroc)
+
+test_that("PlotCbmFit should error on unequal lengths of input", {
+expect_error( PlotCbmFit(c(1, 2), c(0.5)),"The lengths of mu and alpha do not match." )
+})
+
+test_that("PlotCbmFit should return a class that is gg and ggplot", {
+cbmPlot <- PlotCbmFit(c(1, 2), c(0.5, 0.5))
+expect_is( cbmPlot,c("gg","ggplot") )
+})

--- a/tests/testthat/test-SsPowerTable.R
+++ b/tests/testthat/test-SsPowerTable.R
@@ -1,0 +1,10 @@
+context("SsPowerTable tests")
+library(RJafroc)
+
+test_that("SsPowerTable should error on unknown method", {
+expect_error(SsPowerTable(dataset02, method = "UNKNOWN"),"Incorrect method." )
+})
+
+test_that("SsPowerTable should error on unknown dataset", {
+expect_error(SsPowerTable(datasetXTESTX, method = "DBMH"),"not found" )
+})

--- a/tests/testthat/test-SsSampleSizeKGivenJ.R
+++ b/tests/testthat/test-SsSampleSizeKGivenJ.R
@@ -1,0 +1,15 @@
+context("SsSampleSizeKGivenJ tests")
+library(RJafroc)
+
+
+test_that("SsSampleSizeKGivenJ should error on unknown method", {
+  expect_error(SsSampleSizeKGivenJ(dataset02, J = 6, method = "UNKNOWN"),"Incorrect method." )
+})
+
+test_that("SsSampleSizeKGivenJ should be silent using dataset02 and DBMH", {
+  expect_silent(SsSampleSizeKGivenJ(dataset02, J = 6, method = "DBMH"))
+})
+
+test_that("SsSampleSizeKGivenJ should be silent using dataset02 and ORH", {
+  expect_silent(SsSampleSizeKGivenJ(dataset02, J = 6, method = "ORH"))
+})

--- a/tests/testthat/test-StSignificanceTesting.R
+++ b/tests/testthat/test-StSignificanceTesting.R
@@ -1,0 +1,19 @@
+context("StSignificanceTesting tests")
+library(RJafroc)
+
+
+test_that("StSignificanceTesting should error on unknown FOM", {
+  expect_error(StSignificanceTesting(dataset02,FOM = "UNKNOWN", method = "DBMH"),"Must use Wilcoxon figure of merit with ROC data." )
+})
+
+test_that("StSignificanceTesting should error on unknown method", {
+  expect_error(StSignificanceTesting(dataset02,FOM = "Wilcoxon", method = "UNKNOWN"),"is not a valid analysis method." )
+})
+
+test_that("StSignificanceTesting: no warnings/errors using dataset02", {
+  expect_silent(StSignificanceTesting(dataset02,FOM = "Wilcoxon", method = "DBMH"))
+})
+
+test_that("StSignificanceTesting: should error on incorrect FOM with FROC or ROI data", {
+  expect_error(StSignificanceTesting(dataset05,FOM = "Wilcoxon", method = "DBMH"),"Cannot use `Wilcoxon` FOM with `FROC` or `ROI` data.")
+})

--- a/tests/testthat/test-StSignificanceTestingCrossedModalities.R
+++ b/tests/testthat/test-StSignificanceTestingCrossedModalities.R
@@ -1,0 +1,6 @@
+context("StSignificanceTestingCrossedModalities tests")
+library(RJafroc)
+
+test_that("StSignificanceTestingCrossedModalities: no warnings/erros using datasetCrossedModality", {
+expect_silent(StSignificanceTestingCrossedModalities(datasetCrossedModality, 1))
+})

--- a/tests/testthat/test-gpfMyFOM.R
+++ b/tests/testthat/test-gpfMyFOM.R
@@ -1,0 +1,6 @@
+context("gpfMyFOM tests")
+library(RJafroc)
+
+test_that("gpfMyFOM should error on unknown FOM", {
+  expect_error(gpfMyFOM(FOM="TESTFOM"),"is not an available figure of merit." )
+})

--- a/tests/testthat/testData.R
+++ b/tests/testthat/testData.R
@@ -1,0 +1,34 @@
+context("General tests")
+library(RJafroc)
+
+test_that("dataset04 - lesion number is expected", {
+expect_equal(length(dataset04$lesionNum),100)
+})
+
+test_that("Import includedFrocData.xlsx - ROI datatype", {
+fileName <- system.file(
+    "extdata", "includedRoiData.xlsx", package = "RJafroc", mustWork = TRUE)
+ds <- DfReadDataFile(fileName)
+expect_equal(ds$dataType,c("ROI"))
+})
+
+test_that("Import includedFrocData.xlsx - FROC datatype", {
+fileName <- system.file(
+    "extdata", "includedFrocData.xlsx", package = "RJafroc", mustWork = TRUE)
+ds <- DfReadDataFile(fileName)
+expect_equal(ds$dataType,c("FROC"))
+})
+
+test_that("CBMPoints from Ch20V2degenerateROCs",{
+  CBMPoints <- function(mu, alpha){
+  plotZeta <- seq(-20, 20, by = 0.01)
+  FPF <- 1 - pnorm(plotZeta)
+  FPF <- c(1, FPF, 0)
+  TPF <- (1 - alpha) * (1 - pnorm(plotZeta)) + alpha * (1 - pnorm(plotZeta, mean = mu))
+  TPF <- c(1, TPF, 0)
+  plotCurve <- data.frame(FPF = FPF, TPF = TPF)
+  return(plotCurve) }
+  mu <- Inf; alpha <- 0.75
+  plotCurve <- CBMPoints(mu, alpha)
+  expect_equal(length(plotCurve$TPF),4003)
+})


### PR DESCRIPTION
- `testthat` is already suggested in `DESCRIPTION`
- a `tests` directory and `testthat.R` file has been created
- aim to have tests for all major R functions, grouped by R file name
- some tests check a function correctly issues an error
- use `devtools::test()` to run the tests within R
