### PR TITLE
Add info message to expect_equal tests in loops

### DIFF
--- a/tests/testthat/test-FOM.R
+++ b/tests/testthat/test-FOM.R
@@ -45,7 +45,9 @@ test_that("FROC dataset: all FOMs except ...", {
     }
 
     ret1 <- readRDS(fn)
-    expect_equal(UtilFigureOfMerit(dataset, FOM = FOM), ret1)
+    expect_equal(UtilFigureOfMerit(dataset, FOM = FOM), ret1,
+      info = paste0("FOM = ",FOM)
+    )
     # end of test
 
   }
@@ -74,7 +76,9 @@ test_that("FROC data: excessive computation time FOMs", {
     }
 
     ret1 <- readRDS(fn)
-    expect_equal(UtilFigureOfMerit(dataset, FOM = FOM), ret1)
+    expect_equal(UtilFigureOfMerit(dataset, FOM = FOM), ret1,
+      info = paste0("FOM = ",FOM)
+    )
     # end of test
 
   }
@@ -118,7 +122,9 @@ test_that("LROC paradigm: FOM = Wilcoxon, ALROC", {
     }
 
     ret1 <- readRDS(fn)
-    expect_equal(UtilFigureOfMerit(dataset, FOM = FOM), ret1)
+    expect_equal(UtilFigureOfMerit(dataset, FOM = FOM), ret1,
+      info = paste0("FOM = ",FOM)
+    )
     # end of test
 
   }

--- a/tests/testthat/test-StSignificanceTestingCad.R
+++ b/tests/testthat/test-StSignificanceTestingCad.R
@@ -33,7 +33,9 @@ test_that("StSignificanceTestingCadVsRadiologists", {
             saveRDS(ret, file = fn)
           }  
           ret <- readRDS(fn)
-          expect_equal(StSignificanceTestingCadVsRadiologists (dataset, FOM = fom_arr[i], method = method_arr[j]), ret)
+          expect_equal(StSignificanceTestingCadVsRadiologists (dataset, FOM = fom_arr[i], method = method_arr[j]), ret, 
+            info = paste0("Dataset = ",dataset_arr_str[[d]],", FOM = ",fom_arr[i],", method = ",method_arr[j])
+          )
           # end of test
           
         } else if ((dataset$dataType == "ROC") && (fom_arr[i] != "Wilcoxon")) {

--- a/tests/testthat/test-mean-squares.R
+++ b/tests/testthat/test-mean-squares.R
@@ -32,7 +32,9 @@ test_that("UtilMeanSquares", {
           }
           
           ret <- readRDS(fn)
-          expect_equal(UtilMeanSquares(dataset, FOM = FOM_arr[i], method = method_arr[j]), ret)
+          expect_equal(UtilMeanSquares(dataset, FOM = FOM_arr[i], method = method_arr[j]), ret,
+            info = paste0("Dataset = ",dataset_arr_str[[d]],", FOM = ",FOM_arr[i],", method = ",method_arr[j])
+          )
           # end of test
           
           #  }

--- a/tests/testthat/test-significance-testing.R
+++ b/tests/testthat/test-significance-testing.R
@@ -38,7 +38,9 @@ test_that("SignificanceTestingAllCombinations", {
           # causes failure in R CMD check but not in devtools::test(); go figure 6/30/19 !!!dpc!!!
           ret1 <- StSignificanceTesting(dataset, FOM = FOM_arr[i],method = method_arr[j])
           ret1 <- ret1[c(-2,-3)] # removed anovaY and anovaYi list members
-          expect_equal(ret1, ret) # now it works
+          expect_equal(ret1, ret,
+            info = paste0("Dataset = ",dataset_arr_str[[d]],", FOM = ",FOM_arr[i],", method = ",method_arr[j])
+          )
           # end of test
           
         }

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -98,7 +98,9 @@ test_that("UtilPseudoValues", {
     }
 
     ret <- readRDS(fn)
-    expect_equal(UtilPseudoValues(dataset, FOM = FOM_arr[i]), ret)
+    expect_equal(UtilPseudoValues(dataset, FOM = FOM_arr[i]), ret,
+      info = paste0("FOM = ",FOM_arr[i])
+    )
     # end of test
 
   }


### PR DESCRIPTION
- to help identify test errors when using R 3.6.1