### PR TITLE
Fix structure differences across R versions in StSignificanceTesting.R 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ r_packages:
 
 after_success:
   - Rscript -e 'library(covr); codecov()'
-  
+
+

--- a/R/StSignificanceTesting.R
+++ b/R/StSignificanceTesting.R
@@ -435,8 +435,8 @@ StDBMHAnalysis <- function(dataset, FOM = FOM, alpha = 0.05, option = "ALL",
       }
       ciAvgRdrEachTrtRRRC <- data.frame(Treatment = modalityID, 
                                         Area = trMeans, 
-                                        StdErr = stdErrSingleRRRC, 
-                                        DF = dfSingleRRRC, 
+                                        StdErr = as.vector(stdErrSingleRRRC), 
+                                        DF = as.vector(dfSingleRRRC), 
                                         CILower = CISingleRRRC[,1], 
                                         CIUpper = CISingleRRRC[,2], 
                                         row.names = NULL)
@@ -491,8 +491,8 @@ StDBMHAnalysis <- function(dataset, FOM = FOM, alpha = 0.05, option = "ALL",
     }
     ciAvgRdrEachTrtFRRC <- data.frame(Treatment = modalityID, 
                                       Area = trMeans, 
-                                      StdErr = stdErrSingleFRRC, 
-                                      DF = dfSingleFRRC, 
+                                      StdErr = as.vector(stdErrSingleFRRC), 
+                                      DF = as.vector(dfSingleFRRC), 
                                       CILower = CISingleFRRC[,1], 
                                       CIUpper = CISingleFRRC[,2], 
                                       row.names = NULL)
@@ -613,8 +613,8 @@ StDBMHAnalysis <- function(dataset, FOM = FOM, alpha = 0.05, option = "ALL",
       }
       ciAvgRdrEachTrtRRFC <- data.frame(Treatment = modalityID, 
                                         Area = trMeans, 
-                                        StdErr = stdErrSingleRRFC, 
-                                        DF = dfSingleRRFC, 
+                                        StdErr = as.vector(stdErrSingleRRFC), 
+                                        DF = as.vector(dfSingleRRFC), 
                                         CILower = CISingleRRFC[,1], 
                                         CIUpper = CISingleRRFC[,2], 
                                         row.names = NULL)
@@ -840,8 +840,8 @@ StORHAnalysis <- function(dataset, FOM = FOM, alpha = 0.05, covEstMethod = "Jack
       }
       ciAvgRdrEachTrtRRRC <- data.frame(Treatment = modalityID, 
                                         Area = trMeans, 
-                                        StdErr = stdErrSingleRRRC, 
-                                        DF = dfSingleRRRC, 
+                                        StdErr = as.vector(stdErrSingleRRRC), 
+                                        DF = as.vector(dfSingleRRRC), 
                                         CILower = CISingleRRRC[,1], 
                                         CIUpper = CISingleRRRC[,2], 
                                         row.names = NULL)
@@ -900,8 +900,8 @@ StORHAnalysis <- function(dataset, FOM = FOM, alpha = 0.05, covEstMethod = "Jack
     }
     ciAvgRdrEachTrtFRRC <- data.frame(Treatment = modalityID, 
                                       Area = trMeans, 
-                                      StdErr = stdErrSingleFRRC, 
-                                      DF = dfSingleFRRC, 
+                                      StdErr = as.vector(stdErrSingleFRRC), 
+                                      DF = as.vector(dfSingleFRRC), 
                                       CILower = CISingleFRRC[,1], 
                                       CIUpper = CISingleFRRC[,2], 
                                       row.names = NULL)
@@ -996,8 +996,8 @@ StORHAnalysis <- function(dataset, FOM = FOM, alpha = 0.05, covEstMethod = "Jack
       }
       ciAvgRdrEachTrtRRFC <- data.frame(Treatment = modalityID, 
                                         Area = trMeans, 
-                                        StdErr = stdErrSingleRRFC, 
-                                        DF = dfSingleRRFC, 
+                                        StdErr = as.vector(stdErrSingleRRFC), 
+                                        DF = as.vector(dfSingleRRFC), 
                                         CILower = CISingleRRFC[,1], 
                                         CIUpper = CISingleRRFC[,2], 
                                         row.names = NULL)


### PR DESCRIPTION
A bug labelled _Type inconsistency when converting arrays to data frames_ was fixed in R v3.6.1

<https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17570>

The fix changes some simple array structure to a vector when included in a `data.frame`. Older versions <3.6.1 did not do this as expected. This appears to be the source of the errors in the test of `StSignificanceTesting.R`. Do have a look at the simple example code on the bug fix page for more detail.

This pull request adds a `as.vector` call to the relevant parts of the output in `StSignificanceTesting.R` - it should not have any impact for v3.6.1, but bring earlier versions into line. I have added it to  `StSignificanceTesting.R` so sensible output is generated, rather than try to catch the individual issues in the test itself.

Travis should pass on all three versions (versions currently: `oldrel: 3.5.3`; `release: 3.6.0`; `devel:` is a recent pull from R dev tree which will become R 3.6.1). The goodValues (not changed in this pull request) have all been generated previously in R 3.6.1.
