### PR TITLE
Update plot-based expect_equal() tests

### DIFF
--- a/tests/testthat/test-PlotEmpiricalOperatingCharacteristics.R
+++ b/tests/testthat/test-PlotEmpiricalOperatingCharacteristics.R
@@ -9,7 +9,7 @@ test_that("ROC & FROC & vectors & lists", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = seq(1,5), rdrs = seq(1,4), opChType = "wAFROC"), ret)
+  expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = seq(1,5), rdrs = seq(1,4), opChType = "wAFROC"), ret, check.environment = FALSE)
   
   plotT <- list(1, 2, c(1:2), c(1:2))
   plotR <- list(2, c(2:3), c(1:3), 1)
@@ -22,7 +22,7 @@ test_that("ROC & FROC & vectors & lists", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "ROC"), ret)
+  expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "ROC"), ret, check.environment = FALSE)
 
   fn <- paste0(test_path(), "/goodValues361/Plots/ds04-FROC", ".rds")
   if (!file.exists(fn)) {
@@ -32,7 +32,7 @@ test_that("ROC & FROC & vectors & lists", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "FROC"), ret)
+  expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "FROC"), ret, check.environment = FALSE)
 
   fn <- paste0(test_path(), "/goodValues361/Plots/ds04-AFROC", ".rds")
   if (!file.exists(fn)) {
@@ -42,7 +42,7 @@ test_that("ROC & FROC & vectors & lists", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "AFROC"), ret)
+  expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "AFROC"), ret, check.environment = FALSE)
 
   fn <- paste0(test_path(), "/goodValues361/Plots/ds04-wAFROC", ".rds")
   if (!file.exists(fn)) {
@@ -52,7 +52,7 @@ test_that("ROC & FROC & vectors & lists", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "wAFROC"), ret)
+  expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "wAFROC"), ret, check.environment = FALSE)
 
   fn <- paste0(test_path(), "/goodValues361/Plots/ds04-AFROC1", ".rds")
   if (!file.exists(fn)) {
@@ -62,7 +62,7 @@ test_that("ROC & FROC & vectors & lists", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "AFROC1"), ret)
+  expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "AFROC1"), ret, check.environment = FALSE)
 
   fn <- paste0(test_path(), "/goodValues361/Plots/ds04-wAFROC1", ".rds")
   if (!file.exists(fn)) {
@@ -72,7 +72,7 @@ test_that("ROC & FROC & vectors & lists", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "wAFROC1"), ret)
+  expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "wAFROC1"), ret, check.environment = FALSE)
 
 })  
 
@@ -94,7 +94,7 @@ test_that("PlotOperatingCharacteristics-LROC", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(lrocData, opChType = "ROC" ), ret)
+  expect_equal(PlotEmpiricalOperatingCharacteristics(lrocData, opChType = "ROC" ), ret, check.environment = FALSE)
 
   fn <- paste0(test_path(), "/goodValues361/Plots/lrocData-LROC", ".rds")
   if (!file.exists(fn)) {
@@ -104,7 +104,7 @@ test_that("PlotOperatingCharacteristics-LROC", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(lrocData, opChType = "LROC" ), ret)
+  expect_equal(PlotEmpiricalOperatingCharacteristics(lrocData, opChType = "LROC" ), ret, check.environment = FALSE)
   
   plotT <- list(1, 2)
   plotR <- list(seq(1,5), seq(1,5)) # 5 readers
@@ -117,7 +117,7 @@ test_that("PlotOperatingCharacteristics-LROC", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(lrocData, trts = plotT, rdrs = plotR,  opChType = "ROC"), ret)
+  expect_equal(PlotEmpiricalOperatingCharacteristics(lrocData, trts = plotT, rdrs = plotR,  opChType = "ROC"), ret, check.environment = FALSE)
   
   fn <- paste0(test_path(), "/goodValues361/Plots/lrocData-LROC-lists", ".rds")
   if (!file.exists(fn)) {
@@ -127,7 +127,7 @@ test_that("PlotOperatingCharacteristics-LROC", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(lrocData, trts = plotT, rdrs = plotR,  opChType = "LROC"), ret)
+  expect_equal(PlotEmpiricalOperatingCharacteristics(lrocData, trts = plotT, rdrs = plotR,  opChType = "LROC"), ret, check.environment = FALSE)
   
   fn <- paste0(test_path(), "/goodValues361/Plots/lrocData-LROC-vectors", ".rds")
   if (!file.exists(fn)) {
@@ -137,6 +137,6 @@ test_that("PlotOperatingCharacteristics-LROC", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(lrocData, trts = c(1,2), rdrs = seq(1,5),  opChType = "LROC"), ret)
+  expect_equal(PlotEmpiricalOperatingCharacteristics(lrocData, trts = c(1,2), rdrs = seq(1,5),  opChType = "LROC"), ret, check.environment = FALSE)
   
 })

--- a/tests/testthat/test-predicted-plots.R
+++ b/tests/testthat/test-predicted-plots.R
@@ -10,7 +10,7 @@ test_that(contextStr, {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotBinormalFit(c(1, 2), c(0.5, 0.5)), ret)
+  expect_equal(PlotBinormalFit(c(1, 2), c(0.5, 0.5)), ret, check.environment = FALSE)
   # end of test
   
 })
@@ -29,7 +29,7 @@ test_that("PlotCbmFit", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotCbmFit(c(1, 2), c(0.5, 0.5)), ret)
+  expect_equal(PlotCbmFit(c(1, 2), c(0.5, 0.5)), ret, check.environment = FALSE)
   # end of test
   
 })
@@ -68,7 +68,7 @@ test_that("Rsm1", {
                                                zeta1 = zeta1, 
                                                OpChType = "wAFROC",
                                                lesDistr = lesDistr, 
-                                               relWeights = relWeights), ret)
+                                               relWeights = relWeights), ret, check.environment = FALSE)
 
 })
 
@@ -95,7 +95,7 @@ test_that("Rsm2", {
   
   ret <- readRDS(fn)
   expect_equal(PlotRsmOperatingCharacteristics(mu, lambda, nu, OpChType = "wAFROC", 
-                                               lesDistr = lesDistr), ret)
+                                               lesDistr = lesDistr), ret, check.environment = FALSE)
   
 })
 
@@ -121,7 +121,7 @@ test_that("RSM3", {
   
   ret <- readRDS(fn)
   expect_equal(PlotRsmOperatingCharacteristics(mu = c(2, 3), lambda = c(1, 1.5), nu = c(0.6, 0.8), zeta1 = c(-3,-3), OpChType = "wAFROC",
-                                               lesDistr = lesDistr, legendPosition = "bottom", nlfRange = c(0, 1), llfRange = c(0, 1)), ret)
+                                               lesDistr = lesDistr, legendPosition = "bottom", nlfRange = c(0, 1), llfRange = c(0, 1)), ret, check.environment = FALSE)
   
 })
 


### PR DESCRIPTION
Fixes #65 
R-devel (4.1.0) has modified the behaviour of all.equal(), which is used by v2.x of `testthat` for equality testing. R-devel now checks the environment as part of the equality test.

This update disables the environment check explicitly for each equality test on the `ggplot2` output by adding the variable `check.environment = FALSE` in these functions.

The `testthat` package is introducing some breaking changes in version 3.x.x., known as the 3rd Edition.

<https://testthat.r-lib.org/articles/third-edition.html>

The `expect_equal()` function will use `waldo::compare()` rather than the `all.equal()` function.