### PR TITLE
85 issues with next version of ggplot2v3.4.0 rc

### DIFF
--- a/tests/testthat/test-PlotEmpiricalOperatingCharacteristics.R
+++ b/tests/testthat/test-PlotEmpiricalOperatingCharacteristics.R
@@ -10,7 +10,10 @@ test_that("ROC & FROC & vectors & lists", {
   
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = seq(1,5), rdrs = seq(1,4), opChType = "wAFROC"), ret, check.environment = FALSE)
+# expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = seq(1,5), rdrs = seq(1,4), opChType = "wAFROC"), ret, check.environment = FALSE)
+  t <- PlotEmpiricalOperatingCharacteristics(dataset04, trts = seq(1,5), rdrs = seq(1,4), opChType = "wAFROC")
+  expect_is(t$Plot, "ggplot")
+  expect_equal(t$Points, ret$Points, check.environment = FALSE)
   
   plotT <- list(1, 2, c(1:2), c(1:2))
   plotR <- list(2, c(2:3), c(1:3), 1)
@@ -23,7 +26,10 @@ test_that("ROC & FROC & vectors & lists", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "ROC"), ret, check.environment = FALSE)
+# expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "ROC"), ret, check.environment = FALSE)
+  t <- PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "ROC")
+  expect_is(t$Plot, "ggplot")
+  expect_equal(t$Points, ret$Points, check.environment = FALSE)
 
   fn <- paste0(test_path(), "/goodValues361/Plots/ds04-FROC", ".rds")
   if (!file.exists(fn)) {
@@ -33,7 +39,10 @@ test_that("ROC & FROC & vectors & lists", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "FROC"), ret, check.environment = FALSE)
+# expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "FROC"), ret, check.environment = FALSE)
+  t <- PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "FROC")
+  expect_is(t$Plot, "ggplot")
+  expect_equal(t$Points, ret$Points, check.environment = FALSE)
 
   fn <- paste0(test_path(), "/goodValues361/Plots/ds04-AFROC", ".rds")
   if (!file.exists(fn)) {
@@ -43,7 +52,10 @@ test_that("ROC & FROC & vectors & lists", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "AFROC"), ret, check.environment = FALSE)
+# expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "AFROC"), ret, check.environment = FALSE)
+  t <- PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "AFROC")
+  expect_is(t$Plot, "ggplot")
+  expect_equal(t$Points, ret$Points, check.environment = FALSE)
 
   fn <- paste0(test_path(), "/goodValues361/Plots/ds04-wAFROC", ".rds")
   if (!file.exists(fn)) {
@@ -53,7 +65,10 @@ test_that("ROC & FROC & vectors & lists", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "wAFROC"), ret, check.environment = FALSE)
+# expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "wAFROC"), ret, check.environment = FALSE)
+  t <- PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "wAFROC")
+  expect_is(t$Plot, "ggplot")
+  expect_equal(t$Points, ret$Points, check.environment = FALSE)
 
   fn <- paste0(test_path(), "/goodValues361/Plots/ds04-AFROC1", ".rds")
   if (!file.exists(fn)) {
@@ -63,7 +78,10 @@ test_that("ROC & FROC & vectors & lists", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "AFROC1"), ret, check.environment = FALSE)
+# expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "AFROC1"), ret, check.environment = FALSE)
+  t <- PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "AFROC1")
+  expect_is(t$Plot, "ggplot")
+  expect_equal(t$Points, ret$Points, check.environment = FALSE)
 
   fn <- paste0(test_path(), "/goodValues361/Plots/ds04-wAFROC1", ".rds")
   if (!file.exists(fn)) {
@@ -73,7 +91,10 @@ test_that("ROC & FROC & vectors & lists", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "wAFROC1"), ret, check.environment = FALSE)
+# expect_equal(PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "wAFROC1"), ret, check.environment = FALSE)
+  t <- PlotEmpiricalOperatingCharacteristics(dataset04, trts = plotT, rdrs = plotR, opChType = "wAFROC1")
+  expect_is(t$Plot, "ggplot")
+  expect_equal(t$Points, ret$Points, check.environment = FALSE)
 
 })  
 
@@ -95,7 +116,10 @@ test_that("PlotOperatingCharacteristics-LROC", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(lrocData, opChType = "ROC" ), ret, check.environment = FALSE)
+# expect_equal(PlotEmpiricalOperatingCharacteristics(lrocData, opChType = "ROC" ), ret, check.environment = FALSE)
+  t<- PlotEmpiricalOperatingCharacteristics(lrocData, opChType = "ROC" )
+  expect_is(t$Plot, "ggplot")
+  expect_equal(t$Points, ret$Points,check.environment = FALSE)
 
   fn <- paste0(test_path(), "/goodValues361/Plots/lrocData-LROC", ".rds")
   if (!file.exists(fn)) {
@@ -105,7 +129,10 @@ test_that("PlotOperatingCharacteristics-LROC", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(lrocData, opChType = "LROC" ), ret, check.environment = FALSE)
+# expect_equal(PlotEmpiricalOperatingCharacteristics(lrocData, opChType = "LROC" ), ret, check.environment = FALSE)
+  t<-PlotEmpiricalOperatingCharacteristics(lrocData, opChType = "LROC" )
+  expect_is(t$Plot, "ggplot")
+  expect_equal(t$Points, ret$Points, check.environment = FALSE)
   
   plotT <- list(1, 2)
   plotR <- list(seq(1,5), seq(1,5)) # 5 readers
@@ -118,7 +145,11 @@ test_that("PlotOperatingCharacteristics-LROC", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(lrocData, trts = plotT, rdrs = plotR,  opChType = "ROC"), ret, check.environment = FALSE)
+# expect_equal(PlotEmpiricalOperatingCharacteristics(lrocData, trts = plotT, rdrs = plotR,  opChType = "ROC"), ret, check.environment = FALSE)
+  t <- PlotEmpiricalOperatingCharacteristics(lrocData, trts = plotT, rdrs = plotR,  opChType = "ROC")
+  expect_is(t$Plot, "ggplot")
+  expect_equal(t$Points, ret$Points, check.environment = FALSE)
+  
   
   fn <- paste0(test_path(), "/goodValues361/Plots/lrocData-LROC-lists", ".rds")
   if (!file.exists(fn)) {
@@ -128,7 +159,10 @@ test_that("PlotOperatingCharacteristics-LROC", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(lrocData, trts = plotT, rdrs = plotR,  opChType = "LROC"), ret, check.environment = FALSE)
+# expect_equal(PlotEmpiricalOperatingCharacteristics(lrocData, trts = plotT, rdrs = plotR,  opChType = "LROC"), ret, check.environment = FALSE)
+  t<-PlotEmpiricalOperatingCharacteristics(lrocData, trts = plotT, rdrs = plotR,  opChType = "LROC")
+  expect_is(t$Plot, "ggplot")
+  expect_equal(t$Points, ret$Points, check.environment = FALSE)
   
   fn <- paste0(test_path(), "/goodValues361/Plots/lrocData-LROC-vectors", ".rds")
   if (!file.exists(fn)) {
@@ -138,6 +172,9 @@ test_that("PlotOperatingCharacteristics-LROC", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotEmpiricalOperatingCharacteristics(lrocData, trts = c(1,2), rdrs = seq(1,5),  opChType = "LROC"), ret, check.environment = FALSE)
+# expect_equal(PlotEmpiricalOperatingCharacteristics(lrocData, trts = c(1,2), rdrs = seq(1,5),  opChType = "LROC"), ret, check.environment = FALSE)
+  t<- PlotEmpiricalOperatingCharacteristics(lrocData, trts = c(1,2), rdrs = seq(1,5),  opChType = "LROC")
+  expect_is(t$Plot, "ggplot")
+  expect_equal(t$Points, ret$Points, check.environment = FALSE)
   
 })

--- a/tests/testthat/test-predicted-plots.R
+++ b/tests/testthat/test-predicted-plots.R
@@ -11,7 +11,9 @@ test_that(contextStr, {
   
   
   ret <- readRDS(fn)
-  expect_equal(PlotBinormalFit(c(1, 2), c(0.5, 0.5)), ret, check.environment = FALSE)
+# expect_equal(PlotBinormalFit(c(1, 2), c(0.5, 0.5)), ret, check.environment = FALSE)
+  t <- PlotBinormalFit(c(1, 2), c(0.5, 0.5))
+  expect_is(t, "ggplot")
   # end of test
   
 })
@@ -30,7 +32,9 @@ test_that("PlotCbmFit", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotCbmFit(c(1, 2), c(0.5, 0.5)), ret, check.environment = FALSE)
+# expect_equal(PlotCbmFit(c(1, 2), c(0.5, 0.5)), ret, check.environment = FALSE)
+  t <- PlotCbmFit(c(1, 2), c(0.5, 0.5))
+  expect_is(t, "ggplot")
   # end of test
   
 })
@@ -82,13 +86,22 @@ test_that("Rsm1", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotRsmOperatingCharacteristics(mu = mu, 
+# expect_equal(PlotRsmOperatingCharacteristics(mu = mu, 
+#                                                lambda = lambda, 
+#                                                nu = nu, 
+#                                                zeta1 = zeta1, 
+#                                                OpChType = "wAFROC",
+#                                                lesDistr = lesDistr, 
+#                                                relWeights = relWeights), ret, check.environment = FALSE)
+  t <- PlotRsmOperatingCharacteristics(mu = mu, 
                                                lambda = lambda, 
                                                nu = nu, 
                                                zeta1 = zeta1, 
                                                OpChType = "wAFROC",
                                                lesDistr = lesDistr, 
-                                               relWeights = relWeights), ret, check.environment = FALSE)
+                                               relWeights = relWeights)
+  expect_is(t$wAFROCPlot, "ggplot")
+  # end of test
   
 })
 
@@ -118,8 +131,12 @@ test_that("Rsm2", {
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotRsmOperatingCharacteristics(mu, lambda, nu, OpChType = "wAFROC", 
-                                               lesDistr = lesDistr), ret, check.environment = FALSE)
+# expect_equal(PlotRsmOperatingCharacteristics(mu, lambda, nu, OpChType = "wAFROC", 
+#                                              lesDistr = lesDistr), ret, check.environment = FALSE)
+  t <- PlotRsmOperatingCharacteristics(mu, lambda, nu, OpChType = "wAFROC", 
+                                               lesDistr = lesDistr)
+  expect_is(t$wAFROCPlot, "ggplot")
+  # end of test
   
 })
 
@@ -147,12 +164,14 @@ test_that("RSM3", {
   if (!file.exists(fn)) {
     warning(paste0("File not found - generating new ",fn))
     
-    ret <- PlotRsmOperatingCharacteristics(mu = mu, lambda = lambda, nu = nu,  zeta1 = zeta1, OpChType = "wAFROC", lesDistr = lesDistr, legendPosition = "bottom", nlfRange = c(0, 1), llfRange = c(0, 1))
+    ret <- PlotRsmOperatingCharacteristics(mu = mu, lambda = lambda, nu = nu, zeta1 = zeta1, OpChType = "wAFROC", lesDistr = lesDistr, legendPosition = "bottom", nlfRange = c(0, 1), llfRange = c(0, 1))
     saveRDS(ret, file = fn)
   }
   
   ret <- readRDS(fn)
-  expect_equal(PlotRsmOperatingCharacteristics(mu = mu, lambda = lambda, nu = nu,  zeta1 = zeta1, OpChType = "wAFROC", lesDistr = lesDistr, legendPosition = "bottom", nlfRange = c(0, 1), llfRange = c(0, 1)), ret, check.environment = FALSE)
-  
+# expect_equal(PlotRsmOperatingCharacteristics(mu = mu, lambda = lambda, nu = nu,  zeta1 = zeta1, OpChType = "wAFROC", lesDistr = lesDistr, legendPosition = "bottom", nlfRange = c(0, 1), llfRange = c(0, 1)), ret, check.environment = FALSE)
+  t <- PlotRsmOperatingCharacteristics(mu = mu, lambda = lambda, nu = nu,  zeta1 = zeta1, OpChType = "wAFROC", lesDistr = lesDistr, legendPosition = "bottom", nlfRange = c(0, 1), llfRange = c(0, 1))
+  expect_is(t$wAFROCPlot, "ggplot")
+
 })
 


### PR DESCRIPTION
This is attempting to address #85 (and similar issues in the future.) Clearly the structure of ggplot objects has changed slightly compared to our saved test output, used for comparison. This proposed change does not test the content of the ggplot object, only that it is a ggplot object.

If this change is acceptable, there is then an opportunity to reduce the file size of the plotting test comparison files. Currently the `tests/testthat/goodValues361/Plots` directory is 2.1Mb